### PR TITLE
Minimum changes to reproduce the main error on PR #3 and PR #5 addressing issue #2

### DIFF
--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -204,7 +204,7 @@ impl<'a> GitExplorer {
     }
 
     fn paint_branch(
-        &self,
+        &mut self,
         mut commits: Vec<Commit>,
         mut output: Vec<GraphNode>,
         limit_stack: Option<usize>,
@@ -318,7 +318,7 @@ impl<'a> GitExplorer {
         [output, vec_str].concat()
     }
 
-    pub fn paint_commit_track(&self, commit: Commit, branches: Vec<BranchData>) -> Vec<GraphNode> {
+    pub fn paint_commit_track(&mut self, commit: Commit, branches: Vec<BranchData>) -> Vec<GraphNode> {
         // let limit_stack = 1000; // Works fine
         let limit_stack = 500; // Works fine
         // let limit_stack = 10000; // Works, but it is unhandeable :/


### PR DESCRIPTION
This causes the following error message:

![image](https://user-images.githubusercontent.com/3003032/226796651-3c459d71-a40f-4269-b8be-daddb6459636.png)


```
   Compiling git_explorer v0.1.0 (/home/karl/github/KarlHeitmann/rust/git_explorer)
warning: unused import: `Oid`
 --> src/ui/mod.rs:1:24
  |
1 | use git2::{Repository, Oid};
  |                        ^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0502]: cannot borrow `*self` as mutable because it is also borrowed as immutable
   --> src/explorer/mod.rs:171:17
    |
171 |                 self.paint_commit_track(self.repo.head().unwrap().peel_to_commit().unwrap(), branches)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^-------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                 |                       |
    |                 |                       immutable borrow occurs here
    |                 |                       a temporary with access to the immutable borrow is created here ...
    |                 mutable borrow occurs here
172 |             }
    |             - ... and the immutable borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `git2::Reference`
    |
    = note: the temporary is part of an expression at the end of a block;
            consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
    |
171 |                 let x = self.paint_commit_track(self.repo.head().unwrap().peel_to_commit().unwrap(), branches); x
    |                 +++++++                                                                                       +++

For more information about this error, try `rustc --explain E0502`.
warning: `git_explorer` (bin "git_explorer") generated 1 warning
error: could not compile `git_explorer` due to previous error; 1 warning emitted

```